### PR TITLE
[WIP] Google -> NAVER

### DIFF
--- a/src/drivers/google-map.driver.ts
+++ b/src/drivers/google-map.driver.ts
@@ -1,0 +1,105 @@
+import { Coordinate, LatLng } from '../types/coordinate/coordinate.type';
+import { FavoriteFolder } from '../types/favorite/favorite-folder.type';
+import { FailedFavoriteItem, FavoriteItem } from '../types/favorite/favorite-item.type';
+import { ContentWindow } from '../types/window/content-window.type';
+import { Context } from '../types/window/context.type';
+import { AbstractDriver } from './abstract.driver';
+import { usleep } from '../utils/timer';
+
+export class GoogleMapDriver extends AbstractDriver {
+  private static readonly entryURL = 'https://www.google.com/maps/@/data=!4m2!10m1!1e1?entry=ttu';
+
+  public label(): string {
+    return '구글맵';
+  }
+
+  public async toLatLng(contentWindow: ContentWindow, coord: Coordinate): Promise<LatLng> {
+    const latLng: [number, number] = await contentWindow.view.webContents.executeJavaScript(
+      //language=js
+      `(function() {
+                    var __tmp = (new kakao.maps.Coords(${coord.x}, ${coord.y})).toLatLng();
+                    return [__tmp.getLat(), __tmp.getLng()];
+                  })();`,
+    );
+    return {
+      lat: latLng[0],
+      lng: latLng[1],
+    };
+  }
+
+  public async import(contentWindow: ContentWindow): Promise<FavoriteFolder[]> {
+    let proc: ((e: unknown) => void) | null = null;
+    return new Promise<FavoriteFolder[]>((resolve, reject) => {
+      proc = async (e) => {
+        const { webContents } = contentWindow.view;
+
+        // 프로필 이미지로 로그인 여부 체크
+        await contentWindow.waitForPreload();
+        await usleep(2000);
+        const isLogin = await webContents.executeJavaScript(
+          //language=js
+          `Boolean(document.querySelector('img.gb_p'))`,
+        );
+        if (!isLogin) return reject('로그인이 필요합니다.');
+
+        await contentWindow.showLoading();
+
+        // 폴더 가져오기
+        const folderResponse = await webContents.executeJavaScript(
+          //language-js
+          `__Bridge.fetch({
+            method: 'GET',
+            url: 'https://www.google.com/locationhistory/preview/mas?authuser=0&hl=ko&gl=kr&pb=!2m3!1s_jFyZufrE6LJ0-kPrue66As!7e81!15i17409!7m1!1i50!12m1!1i50!15m1!1i50!23m1!1i50!24m1!1i50!38m1!1i50',
+            withCredentials: true,
+          }).then(r => r.data);`,
+        )
+        const parsedFolderList: unknown[] = this.parseResponse(folderResponse)[29][0]
+        const folderList = parsedFolderList.map((listItem: any[]) => ({
+          id: listItem[0][1],
+          name: listItem[1],
+        })).filter(item => item.id); // 속한 아이템 개수가 0개면 id가 없기에, 필터링
+        if (folderList.length <= 0) return reject('가져올 데이터가 없습니다.');
+
+        const folders: FavoriteFolder[] = [];
+        // 아이템 가져오기
+        for (const folder of folderList) {
+          const itemsResponse = await webContents.executeJavaScript(
+            //language-js
+            `__Bridge.fetch({
+              method: 'GET',
+              url: 'https://www.google.com/maps/preview/entitylist/getlist?authuser=0&hl=ko&gl=kr&pb=!1m4!1s${folder.id}!2e2!3m1!1e1!2e2!3e2!4i500!6m3!1sYityZrG1NOvg2roPxLGTiAg!7e81!28e2!16b1',
+            }).then(r => r.data);`,
+          )
+          const parsedItems: unknown[] = this.parseResponse(itemsResponse)[0][8] || [];
+          const items = parsedItems.map((item: any[]) => {
+            const favoriteItem: FavoriteItem = {
+              name: item[2],
+              description: item[3],
+              latLng: { lat: item[1][5][2], lng: item[1][5][3] },
+            }
+            return favoriteItem;
+          });
+          folders.push({ name: folder.name, items });
+        }
+        resolve(folders.filter(folder => folder.items.length));
+      };
+
+      contentWindow.view.webContents.on('dom-ready', proc).loadURL(GoogleMapDriver.entryURL);
+    }).finally(async () => {
+      await contentWindow.hideLoading();
+      if (proc) contentWindow.view.webContents.off('dom-ready', proc);
+    });
+  }
+
+  public export(contentWindow: ContentWindow, context: Context, from: FavoriteFolder[]): Promise<FavoriteFolder[]> {
+    throw new Error('Method not implemented.');
+  }
+
+  public view(contentWindow: ContentWindow, item: FailedFavoriteItem<any>): void {
+    throw new Error('Method not implemented.');
+  }
+
+  private parseResponse(responseText: string) {
+    return JSON.parse(responseText.replace(")]}'\n", ''))
+  }
+}

--- a/src/drivers/google-map.driver.ts
+++ b/src/drivers/google-map.driver.ts
@@ -1,4 +1,3 @@
-import { Coordinate, LatLng } from '../types/coordinate/coordinate.type';
 import { FavoriteFolder } from '../types/favorite/favorite-folder.type';
 import { FailedFavoriteItem, FavoriteItem } from '../types/favorite/favorite-item.type';
 import { ContentWindow } from '../types/window/content-window.type';
@@ -11,20 +10,6 @@ export class GoogleMapDriver extends AbstractDriver {
 
   public label(): string {
     return '구글맵';
-  }
-
-  public async toLatLng(contentWindow: ContentWindow, coord: Coordinate): Promise<LatLng> {
-    const latLng: [number, number] = await contentWindow.view.webContents.executeJavaScript(
-      //language=js
-      `(function() {
-                    var __tmp = (new kakao.maps.Coords(${coord.x}, ${coord.y})).toLatLng();
-                    return [__tmp.getLat(), __tmp.getLng()];
-                  })();`,
-    );
-    return {
-      lat: latLng[0],
-      lng: latLng[1],
-    };
   }
 
   public async import(contentWindow: ContentWindow): Promise<FavoriteFolder[]> {


### PR DESCRIPTION
## AC
구글 → Naver 지도 저장목록 전환이 가능하다.
- 해외인 경우에는 skip.

## TODO
- [x] get google folders (HACK) <- 깔끔한 API가 없음
  - [x] 적당한 진입점 찾기
  - [x] 활용할 적당한 API 찾기
- [ ] convert to NAVER


## Issue
- 구글쪽 데이터에 address가 없고 위경도만 존재함 이렇게 기 존재하던 네이버 export API에 넘기면 place들이 응답값으로 넘어오지 못함.
  - [위경도만 넘길때 예시응답](https://map.naver.com/p/api/entry/addressInfo?lng=127.10889669999999&lat=37.2381222)
  - 리버스 지오코딩 필요할듯 보임 or 네이버에서 위경도 넘기면 place 찾아주는 api가 있을지 확인 
  - 해외인 경우 고민이 필요 (한국 api 사용해서 리버스 지오코딩 후, 없으면 처리안하는 식으로 생각중)